### PR TITLE
Use Map instead of arrays in BaseMatchingReducer

### DIFF
--- a/redux-core/src/main/java/me/tatarka/redux/Reducers.java
+++ b/redux-core/src/main/java/me/tatarka/redux/Reducers.java
@@ -1,5 +1,8 @@
 package me.tatarka.redux;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Utility functions to help you with composing your reducers.
  */
@@ -75,9 +78,7 @@ public class Reducers {
     }
 
     static abstract class BaseMatchReducer<A, S, M> implements Reducer<A, S> {
-        private Object[] matchers = new Object[1];
-        private Reducer[] reducers = new Reducer[1];
-        private int size;
+        private Map<M, Reducer> reducers = new HashMap<>();
 
         BaseMatchReducer() {
         }
@@ -89,25 +90,15 @@ public class Reducers {
             if (reducer == null) {
                 throw new NullPointerException("reducer == null");
             }
-            if (size >= matchers.length) {
-                Object[] newMatchers = new Object[size * 2];
-                System.arraycopy(matchers, 0, newMatchers, 0, size);
-                matchers = newMatchers;
-                Reducer[] newReducers = new Reducer[size * 2];
-                System.arraycopy(reducers, 0, newReducers, 0, size);
-                reducers = newReducers;
-            }
-            matchers[size] = matcher;
-            reducers[size] = reducer;
-            size += 1;
+            reducers.put(matcher, reducer);
         }
 
         @Override
         @SuppressWarnings("unchecked")
         public S reduce(A action, S state) {
-            for (int i = 0; i < matchers.length; i++) {
-                if (match((M) matchers[i], action)) {
-                    return (S) reducers[i].reduce(action, state);
+            for(Map.Entry<M, Reducer> entry : reducers.entrySet()) {
+                if(match(entry.getKey(), action)) {
+                    return (S) entry.getValue().reduce(action, state);
                 }
             }
             return state;

--- a/redux-core/src/main/java/me/tatarka/redux/Reducers.java
+++ b/redux-core/src/main/java/me/tatarka/redux/Reducers.java
@@ -1,7 +1,7 @@
 package me.tatarka.redux;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility functions to help you with composing your reducers.
@@ -78,7 +78,8 @@ public class Reducers {
     }
 
     static abstract class BaseMatchReducer<A, S, M> implements Reducer<A, S> {
-        private Map<M, Reducer> reducers = new HashMap<>();
+        private List<M> matchers = new ArrayList<>();
+        private List<Reducer> reducers = new ArrayList<>();
 
         BaseMatchReducer() {
         }
@@ -90,15 +91,16 @@ public class Reducers {
             if (reducer == null) {
                 throw new NullPointerException("reducer == null");
             }
-            reducers.put(matcher, reducer);
+            matchers.add(matcher);
+            reducers.add(reducer);
         }
 
         @Override
         @SuppressWarnings("unchecked")
         public S reduce(A action, S state) {
-            for(Map.Entry<M, Reducer> entry : reducers.entrySet()) {
-                if(match(entry.getKey(), action)) {
-                    return (S) entry.getValue().reduce(action, state);
+            for(int i = 0; i < matchers.size(); i++) {
+                if(match(matchers.get(i), action)) {
+                    return (S) reducers.get(i).reduce(action, state);
                 }
             }
             return state;

--- a/redux-core/src/test/java/me/tatarka/redux/ReducersTest.java
+++ b/redux-core/src/test/java/me/tatarka/redux/ReducersTest.java
@@ -54,4 +54,41 @@ public class ReducersTest {
 
         assertEquals("test1", state);
     }
+
+    @Test
+    public void matching_reducer_handles_nonmatching_case() {
+        Reducer<String, String> stringReducer = Reducers.id();
+
+        Reducer<Object, String> matching = Reducers.<Object, String>matchClass()
+                .when(String.class, stringReducer)
+                .when(String.class, stringReducer)
+                .when(String.class, stringReducer);
+
+        String state = matching.reduce(new Object(), "123");
+        assertEquals("123", state);
+    }
+
+    @Test
+    public void matching_reducer_runs_first_matching_reducer() {
+        Reducer<String, String> shouldNotRun = new Reducer<String, String>() {
+            @Override
+            public String reduce(String action, String state) {
+                return "X";
+            }
+        };
+        Reducer<String, String> shouldRun = new Reducer<String, String>() {
+            @Override
+            public String reduce(String action, String state) {
+                return "valid";
+            }
+        };
+
+        Reducer<String, String> matching = Reducers.<String, String>matchValue()
+                .when("action1", shouldNotRun)
+                .when("action2", shouldRun)
+                .when("action3", shouldNotRun);
+
+        String state = matching.reduce("action2", "don'tcare");
+        assertEquals("valid", state);
+    }
 }


### PR DESCRIPTION
Fixes issue where NullPointerException would occur with a matching reducer
if the number of sub-reducers was not a power of two and no match happened.