### PR TITLE
Upgrade android-gradle-plugin and gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'ru.vyarus:gradle-pom-plugin:1.1.0'
-        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'ru.vyarus:gradle-pom-plugin:1.1.0'
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/redux-android-lifecycle/build.gradle
+++ b/redux-android-lifecycle/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply from: '../publish.gradle'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 27
 
     defaultConfig {
         minSdkVersion 14

--- a/redux-android-lifecycle/build.gradle
+++ b/redux-android-lifecycle/build.gradle
@@ -3,7 +3,6 @@ apply from: '../publish.gradle'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 14
@@ -16,8 +15,9 @@ android {
 }
 
 dependencies {
-    compile project(':redux-android')
-    compile "android.arch.lifecycle:runtime:1.0.0-alpha9"
-    compile "android.arch.lifecycle:extensions:1.0.0-alpha9"
+    implementation project(':redux-core')
+    implementation project(':redux-android')
+    api "android.arch.lifecycle:runtime:1.0.0-alpha9"
+    api "android.arch.lifecycle:extensions:1.0.0-alpha9"
     annotationProcessor "android.arch.lifecycle:compiler:1.0.0-alpha9"
 }

--- a/redux-android/build.gradle
+++ b/redux-android/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.library'
 apply from: '../publish.gradle'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 11
+        minSdkVersion 14
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -14,7 +14,7 @@ android {
 
 dependencies {
     implementation project(':redux-core')
-    implementation 'com.android.support:support-v4:25.3.1'
+    implementation 'com.android.support:support-v4:27.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test:rules:1.0.1'

--- a/redux-android/build.gradle
+++ b/redux-android/build.gradle
@@ -3,7 +3,6 @@ apply from: '../publish.gradle'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 11
@@ -14,12 +13,12 @@ android {
 }
 
 dependencies {
-    compile project(':redux-core')
-    compile 'com.android.support:support-v4:25.3.1'
-    testCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
-    androidTestCompile 'com.android.support.test:rules:1.0.1'
-    androidTestCompile 'io.reactivex:rxjava:1.2.1'
-    androidTestCompile 'org.assertj:assertj-core:2.5.0'
+    implementation project(':redux-core')
+    implementation 'com.android.support:support-v4:25.3.1'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'io.reactivex:rxjava:1.2.1'
+    androidTestImplementation 'org.assertj:assertj-core:2.5.0'
 }
 

--- a/redux-core/build.gradle
+++ b/redux-core/build.gradle
@@ -4,6 +4,6 @@ apply from: '../publish.gradle'
 sourceCompatibility = 1.7
 
 dependencies {
-    testCompile 'io.reactivex:rxjava:1.2.1'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'io.reactivex:rxjava:1.2.1'
+    testImplementation 'junit:junit:4.12'
 }

--- a/redux-monitor/build.gradle
+++ b/redux-monitor/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':redux-core')
     implementation 'io.github.sac:SocketclusterClientJava:1.7.2'
 
-    testCompile 'io.reactivex:rxjava:1.2.1'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'io.reactivex:rxjava:1.2.1'
+    testImplementation 'junit:junit:4.12'
 }
 

--- a/redux-replay/build.gradle
+++ b/redux-replay/build.gradle
@@ -8,6 +8,6 @@ repositories {
 }
 
 dependencies {
-    compile project(':redux-core')
-    testCompile 'junit:junit:4.12'
+    implementation project(':redux-core')
+    testImplementation 'junit:junit:4.12'
 }

--- a/redux-rx/build.gradle
+++ b/redux-rx/build.gradle
@@ -4,7 +4,7 @@ apply from: '../publish.gradle'
 sourceCompatibility = 1.7
 
 dependencies {
-    compile project(':redux-core')
-    compile 'io.reactivex:rxjava:1.2.1'
-    testCompile 'junit:junit:4.12'
+    implementation project(':redux-core')
+    implementation 'io.reactivex:rxjava:1.2.1'
+    testImplementation 'junit:junit:4.12'
 }

--- a/redux-rx2/build.gradle
+++ b/redux-rx2/build.gradle
@@ -4,7 +4,7 @@ apply from: '../publish.gradle'
 sourceCompatibility = 1.7
 
 dependencies {
-    compile project(':redux-core')
-    compile 'io.reactivex.rxjava2:rxjava:2.0.4'
-    testCompile 'junit:junit:4.12'
+    implementation project(':redux-core')
+    implementation 'io.reactivex.rxjava2:rxjava:2.0.4'
+    testImplementation 'junit:junit:4.12'
 }

--- a/redux-thunk/build.gradle
+++ b/redux-thunk/build.gradle
@@ -4,6 +4,6 @@ apply from: '../publish.gradle'
 sourceCompatibility = 1.7
 
 dependencies {
-    compile project(':redux-core')
-    testCompile 'junit:junit:4.12'
+    implementation project(':redux-core')
+    testImplementation 'junit:junit:4.12'
 }

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -12,7 +12,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "com.example.sample_android"
@@ -31,17 +30,17 @@ android {
 }
 
 dependencies {
-    compile project(':redux-core')
-    compile project(':redux-android')
-    compile project(':redux-android-lifecycle')
-    compile project(':redux-replay')
-    compile project(':redux-thunk')
-    compile project(':redux-monitor')
+    implementation project(':redux-core')
+    implementation project(':redux-android')
+    implementation project(':redux-android-lifecycle')
+    implementation project(':redux-replay')
+    implementation project(':redux-thunk')
+    implementation project(':redux-monitor')
 
-    compile 'com.android.support:appcompat-v7:26.0.2'
-    compile 'com.android.support:design:26.0.2'
-    compile 'com.jakewharton.auto.value:auto-value-annotations:1.3'
+    implementation 'com.android.support:appcompat-v7:26.0.2'
+    implementation 'com.android.support:design:26.0.2'
+    implementation 'com.jakewharton.auto.value:auto-value-annotations:1.3'
     annotationProcessor 'com.google.auto.value:auto-value:1.3'
-    
-    testCompile 'junit:junit:4.12'
+
+    testImplementation 'junit:junit:4.12'
 }

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -4,19 +4,18 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
 
     defaultConfig {
         applicationId "com.example.sample_android"
         minSdkVersion 19
-        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true
@@ -37,8 +36,8 @@ dependencies {
     implementation project(':redux-thunk')
     implementation project(':redux-monitor')
 
-    implementation 'com.android.support:appcompat-v7:26.0.2'
-    implementation 'com.android.support:design:26.0.2'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
     implementation 'com.jakewharton.auto.value:auto-value-annotations:1.3'
     annotationProcessor 'com.google.auto.value:auto-value:1.3'
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 sourceCompatibility = 1.8
 
 dependencies {
-    compile project(':redux-core')
-    compile project(':redux-rx')
-    compile 'io.reactivex:rxjava:1.2.1'
+    implementation project(':redux-core')
+    implementation project(':redux-rx')
+    implementation 'io.reactivex:rxjava:1.2.1'
 }


### PR DESCRIPTION
* Upgrade android-gradle-plugin to v 3.5.3
* Upgrade gradle to version 5.4.1
* Upgrade android-support-library to version 27.1.1
* remove buildToolsVersion - since v3.1.0 you no longer need to specify a version for the build tools using the android.buildToolsVersion property—the plugin uses the minimum required version by default.